### PR TITLE
Update log4j package name

### DIFF
--- a/log4jSyslogWriter64k/src/main/java/com/github/loggly/log4j/SyslogAppender64k.java
+++ b/log4jSyslogWriter64k/src/main/java/com/github/loggly/log4j/SyslogAppender64k.java
@@ -1,4 +1,4 @@
-package com.github.psquickitjayant.log4j;
+package com.github.loggly.log4j;
 
 import org.apache.log4j.AppenderSkeleton;
 import org.apache.log4j.Layout;
@@ -12,8 +12,7 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.io.IOException;
 
-import com.github.psquickitjayant.log4j.helpers.SyslogWriter64k;
-
+import com.github.loggly.log4j.helpers.SyslogWriter64k;
 
 /**
     Use SyslogAppender64k to send log messages upto 64K to a remote syslog daemon.

--- a/log4jSyslogWriter64k/src/main/java/com/github/loggly/log4j/helpers/SyslogWriter64k.java
+++ b/log4jSyslogWriter64k/src/main/java/com/github/loggly/log4j/helpers/SyslogWriter64k.java
@@ -1,4 +1,4 @@
-package com.github.psquickitjayant.log4j.helpers;
+package com.github.loggly.log4j.helpers;
 
 
 import java.io.Writer;


### PR DESCRIPTION
@mchaudhary In this PR, I updated the package name from **psquikcitjayant** to **loggly** and also updated all the references of the package. The package name should be replaced at 3 places listed below-

https://github.com/loggly/log4j-syslogwriter-64k/blob/master/log4jSyslogWriter64k/src/main/java/com/github/psquickitjayant/log4j/SyslogAppender64k.java#L1

https://github.com/loggly/log4j-syslogwriter-64k/blob/master/log4jSyslogWriter64k/src/main/java/com/github/psquickitjayant/log4j/SyslogAppender64k.java#L15

https://github.com/loggly/log4j-syslogwriter-64k/blob/master/log4jSyslogWriter64k/src/main/java/com/github/psquickitjayant/log4j/helpers/SyslogWriter64k.java#L1

Please review the changes.  